### PR TITLE
Improves RX reliability

### DIFF
--- a/module.c
+++ b/module.c
@@ -15,7 +15,7 @@
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Adriano Marto Reis");
 MODULE_DESCRIPTION("Software-UART for Raspberry Pi");
-MODULE_VERSION("0.1");
+MODULE_VERSION("0.2");
 
 static int gpio_tx = 17;
 module_param(gpio_tx, int, 0);

--- a/raspberry_soft_uart.c
+++ b/raspberry_soft_uart.c
@@ -182,7 +182,7 @@ static irq_handler_t handle_rx_start(unsigned int irq, void* device, struct pt_r
 {
   if (rx_bit_index == -1)
   {
-    hrtimer_start(&timer_rx, ktime_set(0, 0), HRTIMER_MODE_REL);
+    hrtimer_start(&timer_rx, ktime_set(0, period / 2), HRTIMER_MODE_REL);
   }
   return (irq_handler_t) IRQ_HANDLED;
 }


### PR DESCRIPTION
The RX GPIO was polled exactly at the transition time from one bit to the next. If the transmitting device presents some jitter or is simply a bit late driving its TX line, soft_uart could fail to detect the correct value on bit level transitions. This change simply starts the polling timer not immediately on the start bit interrupt, but a half bit period later, so that all RX GPIO level polling now occurs at the center of each bit, making the RX side of soft_uart more robust.