### PR TITLE
Update module.c to fix compilation errors

### DIFF
--- a/module.c
+++ b/module.c
@@ -156,10 +156,7 @@ static void __exit soft_uart_exit(void)
   }
   
   // Unregisters the driver.
-  if (tty_unregister_driver(soft_uart_driver))
-  {
-    printk(KERN_ALERT "soft_uart: Failed to unregister the driver.\n");
-  }
+  tty_unregister_driver(soft_uart_driver);
 
   tty_driver_kref_put(soft_uart_driver);
   printk(KERN_INFO "soft_uart: Module finalized.\n");

--- a/module.c
+++ b/module.c
@@ -27,9 +27,9 @@ module_param(gpio_rx, int, 0);
 static int  soft_uart_open(struct tty_struct*, struct file*);
 static void soft_uart_close(struct tty_struct*, struct file*);
 static int  soft_uart_write(struct tty_struct*, const unsigned char*, int);
-static int  soft_uart_write_room(struct tty_struct*);
+static unsigned int soft_uart_write_room(struct tty_struct*);
 static void soft_uart_flush_buffer(struct tty_struct*);
-static int  soft_uart_chars_in_buffer(struct tty_struct*);
+static unsigned int soft_uart_chars_in_buffer(struct tty_struct*);
 static void soft_uart_set_termios(struct tty_struct*, struct ktermios*);
 static void soft_uart_stop(struct tty_struct*);
 static void soft_uart_start(struct tty_struct*);
@@ -232,7 +232,7 @@ static int soft_uart_write(struct tty_struct* tty, const unsigned char* buffer, 
  * @param tty given TTY
  * @return number of bytes
  */
-static int soft_uart_write_room(struct tty_struct* tty)
+static unsigned int soft_uart_write_room(struct tty_struct* tty)
 {
   return raspberry_soft_uart_get_tx_queue_room();
 }
@@ -250,7 +250,7 @@ static void soft_uart_flush_buffer(struct tty_struct* tty)
  * @param tty given TTY
  * @return number of bytes
  */
-static int soft_uart_chars_in_buffer(struct tty_struct* tty)
+static unsigned int soft_uart_chars_in_buffer(struct tty_struct* tty)
 {
   return raspberry_soft_uart_get_tx_queue_size();
 }

--- a/module.c
+++ b/module.c
@@ -134,7 +134,7 @@ static int __init soft_uart_init(void)
   if (tty_register_driver(soft_uart_driver))
   {
     printk(KERN_ALERT "soft_uart: Failed to register the driver.\n");
-    put_tty_driver(soft_uart_driver);
+    tty_driver_kref_put(soft_uart_driver);
     return -1; // return if registration fails
   }
 
@@ -161,7 +161,7 @@ static void __exit soft_uart_exit(void)
     printk(KERN_ALERT "soft_uart: Failed to unregister the driver.\n");
   }
 
-  put_tty_driver(soft_uart_driver);
+  tty_driver_kref_put(soft_uart_driver);
   printk(KERN_INFO "soft_uart: Module finalized.\n");
 }
 

--- a/module.c
+++ b/module.c
@@ -84,7 +84,6 @@ static int __init soft_uart_init(void)
 
   // Initializes the port.
   tty_port_init(&port);
-  port.low_latency = 0;
 
   // Allocates the driver.
   soft_uart_driver = tty_alloc_driver(N_PORTS, TTY_DRIVER_REAL_RAW);


### PR DESCRIPTION
Changes in the newer Linux versions cause compilation errors during make. These errors were caused by the following changes in the Linux kernel.

- tty_port::low_latency was removed in linux v5.12
- tty_unregister_driver() returns void instead of int as of linux v5.13
- tty_operations::write_room() and tty_operations::chars_in_buffer() returns uint instead of int as of linux v5.14
- Alias for tty_driver_kref_put(), put_tty_driver() was removed in linux v5.15

This commit make changes to module.c to fix these issues. 
Tested on Raspberry Pi Zero 2 W, with Raspbian OS 11.4, kernel Linux v5.15.32-v7+, gcc  (Raspbian 10.2.1-6+rpi1) 10.2.1 20210110