### PR TITLE
Fixes for  linux headers 6.6.62

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,22 @@ I haven't tried cross-compiling this module, but it should work as well.
 
 Module parameters:
 
-* gpio_tx: int [default = 17]
-* gpio_rx: int [default = 27]
+* gpio_tx: int [default = 529]
+* gpio_rx: int [default = 539]
 
 Loading the module with default parameters:
 ```
 sudo insmod soft_uart.ko
 ```
 
-Loading module with custom parameters:
+Look up GPIO number using the following command, for setting up pins other than the default.
 ```
-sudo insmod soft_uart.ko gpio_tx=10 gpio_rx=11
+cat /sys/kernel/debug/gpio
+```
+
+Loading module with custom parameters with (GPIO17:529) as TX and (GPIO27:539) as RX:
+```
+sudo insmod soft_uart.ko gpio_tx=529 gpio_rx=539
 ```
 
 

--- a/module.c
+++ b/module.c
@@ -17,20 +17,20 @@ MODULE_AUTHOR("Adriano Marto Reis");
 MODULE_DESCRIPTION("Software-UART for Raspberry Pi");
 MODULE_VERSION("0.2");
 
-static int gpio_tx = 17;
+static int gpio_tx = 529;
 module_param(gpio_tx, int, 0);
 
-static int gpio_rx = 27;
+static int gpio_rx = 539;
 module_param(gpio_rx, int, 0);
 
 // Module prototypes.
 static int  soft_uart_open(struct tty_struct*, struct file*);
 static void soft_uart_close(struct tty_struct*, struct file*);
-static int  soft_uart_write(struct tty_struct*, const unsigned char*, int);
+static long int  soft_uart_write(struct tty_struct*, const unsigned char*, long unsigned int);
 static unsigned int soft_uart_write_room(struct tty_struct*);
 static void soft_uart_flush_buffer(struct tty_struct*);
 static unsigned int soft_uart_chars_in_buffer(struct tty_struct*);
-static void soft_uart_set_termios(struct tty_struct*, struct ktermios*);
+static void soft_uart_set_termios(struct tty_struct*, const struct ktermios*);
 static void soft_uart_stop(struct tty_struct*);
 static void soft_uart_start(struct tty_struct*);
 static void soft_uart_hangup(struct tty_struct*);
@@ -218,7 +218,7 @@ static void soft_uart_close(struct tty_struct* tty, struct file* file)
  * @param buffer_size number of bytes contained in the given buffer
  * @return number of bytes successfuly written into the TTY device
  */
-static int soft_uart_write(struct tty_struct* tty, const unsigned char* buffer, int buffer_size)
+static long int soft_uart_write(struct tty_struct* tty, const unsigned char* buffer, long unsigned buffer_size)
 {
   return raspberry_soft_uart_send_string(buffer, buffer_size);
 }
@@ -256,7 +256,7 @@ static unsigned int soft_uart_chars_in_buffer(struct tty_struct* tty)
  * @param tty given TTY
  * @param termios parameters
  */
-static void soft_uart_set_termios(struct tty_struct* tty, struct ktermios* termios)
+static void soft_uart_set_termios(struct tty_struct* tty, const struct ktermios* termios)
 {
   int cflag = 0;
   speed_t baudrate = tty_get_baud_rate(tty);

--- a/module.c
+++ b/module.c
@@ -72,13 +72,13 @@ static struct tty_port port;
 static int __init soft_uart_init(void)
 {
   printk(KERN_INFO "soft_uart: Initializing module...\n");
-  
+
   if (!raspberry_soft_uart_init(gpio_tx, gpio_rx))
   {
     printk(KERN_ALERT "soft_uart: Failed initialize GPIO.\n");
     return -ENOMEM;
   }
-    
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
   printk(KERN_INFO "soft_uart: LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0).\n");
 
@@ -148,13 +148,13 @@ static int __init soft_uart_init(void)
 static void __exit soft_uart_exit(void)
 {
   printk(KERN_INFO "soft_uart: Finalizing the module...\n");
-  
+
   // Finalizes the soft UART.
   if (!raspberry_soft_uart_finalize())
   {
     printk(KERN_ALERT "soft_uart: Something went wrong whilst finalizing the soft UART.\n");
   }
-  
+
   // Unregisters the driver.
   tty_unregister_driver(soft_uart_driver);
 
@@ -171,7 +171,7 @@ static void __exit soft_uart_exit(void)
 static int soft_uart_open(struct tty_struct* tty, struct file* file)
 {
   int error = NONE;
-    
+
   if (raspberry_soft_uart_open(tty))
   {
     printk(KERN_INFO "soft_uart: Device opened.\n");
@@ -181,7 +181,7 @@ static int soft_uart_open(struct tty_struct* tty, struct file* file)
     printk(KERN_ALERT "soft_uart: Device busy.\n");
     error = -ENODEV;
   }
-  
+
   return error;
 }
 
@@ -200,7 +200,7 @@ static void soft_uart_close(struct tty_struct* tty, struct file* file)
     msleep(100);
     wait_time += 100;
   }
-  
+
   if (raspberry_soft_uart_close())
   {
     printk(KERN_INFO "soft_uart: Device closed.\n");
@@ -274,19 +274,19 @@ static void soft_uart_set_termios(struct tty_struct* tty, const struct ktermios*
   {
     printk(KERN_ALERT "soft_uart: Invalid number of data bits.\n");
   }
-  
+
   // Verifies the number of stop bits (it must be 1).
   if (cflag & CSTOPB)
   {
     printk(KERN_ALERT "soft_uart: Invalid number of stop bits.\n");
   }
-  
+
   // Verifies the parity (it must be none).
   if (cflag & PARENB)
   {
     printk(KERN_ALERT "soft_uart: Invalid parity.\n");
   }
-  
+
   // Configure the baudrate.
   if (!raspberry_soft_uart_set_baudrate(baudrate))
   {
@@ -356,11 +356,11 @@ static int soft_uart_ioctl(struct tty_struct* tty, unsigned int command, unsigne
     case TIOCMSET:
       error = NONE;
       break;
- 
+
     case TIOCMGET:
       error = NONE;
       break;
-      
+
       default:
         error = -ENOIOCTLCMD;
         break;

--- a/module.c
+++ b/module.c
@@ -76,6 +76,7 @@ static int __init soft_uart_init(void)
   if (!raspberry_soft_uart_init(gpio_tx, gpio_rx))
   {
     printk(KERN_ALERT "soft_uart: Failed initialize GPIO.\n");
+    raspberry_soft_uart_finalize();
     return -ENOMEM;
   }
 

--- a/raspberry_soft_uart.c
+++ b/raspberry_soft_uart.c
@@ -96,6 +96,7 @@ int raspberry_soft_uart_open(struct tty_struct* tty)
     current_tty = tty;
     initialize_queue(&queue_tx);
     success = 1;
+    rx_bit_index = -1;
     enable_irq(gpio_to_irq(gpio_rx));
   }
   mutex_unlock(&current_tty_mutex);

--- a/raspberry_soft_uart.c
+++ b/raspberry_soft_uart.c
@@ -2,7 +2,7 @@
 #include "raspberry_soft_uart.h"
 #include "queue.h"
 
-#include <linux/gpio.h> 
+#include <linux/gpio.h>
 #include <linux/hrtimer.h>
 #include <linux/interrupt.h>
 #include <linux/ktime.h>
@@ -37,27 +37,27 @@ static int rx_bit_index = -1;
 int raspberry_soft_uart_init(const int _gpio_tx, const int _gpio_rx)
 {
   bool success = true;
-  
+
   mutex_init(&current_tty_mutex);
-  
+
   // Initializes the TX timer.
   hrtimer_init(&timer_tx, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
   timer_tx.function = &handle_tx;
-  
+
   // Initializes the RX timer.
   hrtimer_init(&timer_rx, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
   timer_rx.function = &handle_rx;
-  
+
   // Initializes the GPIO pins.
   gpio_tx = _gpio_tx;
   gpio_rx = _gpio_rx;
-    
+
   success &= gpio_request(gpio_tx, "soft_uart_tx") == 0;
   success &= gpio_direction_output(gpio_tx, 1) == 0;
 
   success &= gpio_request(gpio_rx, "soft_uart_rx") == 0;
   success &= gpio_direction_input(gpio_rx) == 0;
-  
+
   // Initializes the interruption.
   success &= request_irq(
     gpio_to_irq(gpio_rx),
@@ -66,7 +66,7 @@ int raspberry_soft_uart_init(const int _gpio_tx, const int _gpio_rx)
     "soft_uart_irq_handler",
     NULL) == 0;
   disable_irq(gpio_to_irq(gpio_rx));
-    
+
   return success;
 }
 
@@ -126,7 +126,7 @@ int raspberry_soft_uart_close(void)
  * @param baudrate desired baudrate
  * @return 1 if the operation is successful. 0 otherwise.
  */
-int raspberry_soft_uart_set_baudrate(const int baudrate) 
+int raspberry_soft_uart_set_baudrate(const int baudrate)
 {
   period = ktime_set(0, 1000000000/baudrate);
   gpiod_set_debounce(gpio_to_desc(gpio_rx), 1000/baudrate/2);
@@ -142,13 +142,13 @@ int raspberry_soft_uart_set_baudrate(const int baudrate)
 int raspberry_soft_uart_send_string(const unsigned char* string, int string_size)
 {
   int result = enqueue_string(&queue_tx, string, string_size);
-  
+
   // Starts the TX timer if it is not already running.
   if (!hrtimer_active(&timer_tx))
   {
     hrtimer_start(&timer_tx, period, HRTIMER_MODE_REL);
   }
-  
+
   return result;
 }
 
@@ -198,7 +198,7 @@ static enum hrtimer_restart handle_tx(struct hrtimer* timer)
   static int bit_index = -1;
   enum hrtimer_restart result = HRTIMER_NORESTART;
   bool must_restart_timer = false;
-  
+
   // Start bit.
   if (bit_index == -1)
   {
@@ -209,7 +209,7 @@ static enum hrtimer_restart handle_tx(struct hrtimer* timer)
       must_restart_timer = true;
     }
   }
-  
+
   // Data bits.
   else if (0 <= bit_index && bit_index < 8)
   {
@@ -217,7 +217,7 @@ static enum hrtimer_restart handle_tx(struct hrtimer* timer)
     bit_index++;
     must_restart_timer = true;
   }
-  
+
   // Stop bit.
   else if (bit_index == 8)
   {
@@ -226,14 +226,14 @@ static enum hrtimer_restart handle_tx(struct hrtimer* timer)
     bit_index = -1;
     must_restart_timer = get_queue_size(&queue_tx) > 0;
   }
-  
+
   // Restarts the TX timer.
   if (must_restart_timer)
   {
     hrtimer_forward(&timer_tx, current_time, period);
     result = HRTIMER_RESTART;
   }
-  
+
   return result;
 }
 
@@ -247,7 +247,7 @@ static enum hrtimer_restart handle_rx(struct hrtimer* timer)
   int bit_value = gpio_get_value(gpio_rx);
   enum hrtimer_restart result = HRTIMER_NORESTART;
   bool must_restart_timer = false;
-  
+
   // Start bit.
   if (rx_bit_index == -1)
   {
@@ -255,7 +255,7 @@ static enum hrtimer_restart handle_rx(struct hrtimer* timer)
     character = 0;
     must_restart_timer = true;
   }
-  
+
   // Data bits.
   else if (0 <= rx_bit_index && rx_bit_index < 8)
   {
@@ -267,26 +267,26 @@ static enum hrtimer_restart handle_rx(struct hrtimer* timer)
     {
       character |= 0x0100;
     }
-    
+
     rx_bit_index++;
     character >>= 1;
     must_restart_timer = true;
   }
-  
+
   // Stop bit.
   else if (rx_bit_index == 8)
   {
     receive_character(character);
     rx_bit_index = -1;
   }
-  
+
   // Restarts the RX timer.
   if (must_restart_timer)
   {
     hrtimer_forward(&timer_rx, current_time, period);
     result = HRTIMER_RESTART;
   }
-  
+
   return result;
 }
 

--- a/raspberry_soft_uart.c
+++ b/raspberry_soft_uart.c
@@ -10,7 +10,7 @@
 #include <linux/tty_flip.h>
 #include <linux/version.h>
 
-static irq_handler_t handle_rx_start(unsigned int irq, void* device, struct pt_regs* registers);
+static irqreturn_t handle_rx_start(unsigned int irq, void* device);
 static enum hrtimer_restart handle_tx(struct hrtimer* timer);
 static enum hrtimer_restart handle_rx(struct hrtimer* timer);
 static void receive_character(unsigned char character);
@@ -129,7 +129,7 @@ int raspberry_soft_uart_close(void)
 int raspberry_soft_uart_set_baudrate(const int baudrate) 
 {
   period = ktime_set(0, 1000000000/baudrate);
-  gpio_set_debounce(gpio_rx, 1000/baudrate/2);
+  gpiod_set_debounce(gpio_to_desc(gpio_rx), 1000/baudrate/2);
   return 1;
 }
 
@@ -178,13 +178,13 @@ int raspberry_soft_uart_get_tx_queue_size(void)
  * If we are waiting for the RX start bit, then starts the RX timer. Otherwise,
  * does nothing.
  */
-static irq_handler_t handle_rx_start(unsigned int irq, void* device, struct pt_regs* registers)
+static irqreturn_t handle_rx_start(unsigned int irq, void* device)
 {
   if (rx_bit_index == -1)
   {
     hrtimer_start(&timer_rx, ktime_set(0, period / 2), HRTIMER_MODE_REL);
   }
-  return (irq_handler_t) IRQ_HANDLED;
+  return (irqreturn_t) IRQ_HANDLED;
 }
 
 


### PR DESCRIPTION
Compilation fixes for Tested on PI Zero,  Linux 6.6.62+rpt-rpi-v8 Bookworm

Details:
![image](https://github.com/user-attachments/assets/4b895ac6-6166-43e3-9ce7-79d2c7ba7d3a)
